### PR TITLE
Fix CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ Source/Utility/dcblock.cpp
 Source/Utility/jitter.cpp
 Source/Utility/metro.cpp
 Source/Utility/port.cpp
+Source/Utility/wavetables.cpp
 )
 
 

--- a/Source/Synthesis/wavetable_osc.h
+++ b/Source/Synthesis/wavetable_osc.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef DSY_WAVETABLEOSC_H
+#define DSY_WAVETABLEOSC_H
+
 #include "wavetables.h"
 
 namespace daisysp
@@ -134,3 +137,4 @@ class WavetableOsc
 };
 
 } // namespace daisysp
+#endif

--- a/Source/Utility/wavetables.cpp
+++ b/Source/Utility/wavetables.cpp
@@ -1,4 +1,4 @@
-#include "wavetables.cpp"
+#include "wavetables.h"
 
 // hackish way to make it work for both mcu and computer
 #ifndef DSY_SDRAM_BSS

--- a/Source/Utility/wavetables.h
+++ b/Source/Utility/wavetables.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef DSY_WAVETABLES_H
+#define DSY_WAVETABLES_H
+
 #include <math.h>
 #include <array>
 #include <vector>
@@ -388,3 +391,4 @@ struct Tables
 };
 
 } // namespace daisysp
+#endif


### PR DESCRIPTION
This pull request adds the Wavetable Oscillator files to the CMake build system, so it can be used to generate custom Makefiles. 

It also adds header guards to these files, fixing a circular dependency bug, according to the project guidelines.