### PR TITLE
Converts Tables struct into a template class

### DIFF
--- a/Source/Utility/wavetables.cpp
+++ b/Source/Utility/wavetables.cpp
@@ -7,14 +7,22 @@
 
 namespace daisysp
 {
-bool Tables::generated = false;
 
-WaveBuffer DSY_SDRAM_BSS Tables::buffer_pool[40];
-uint8_t                  Tables::num_buffers = 0;
+template<typename T, FFTFunction<T> fft> 
+bool Tables<T, fft>::generated = false;
 
-WaveTable Tables::Sine;
-WaveTable Tables::Square;
-WaveTable Tables::Tri;
-WaveTable Tables::Saw;
+template<typename T, FFTFunction<T> fft>
+WaveBuffer DSY_SDRAM_BSS Tables<T, fft>::buffer_pool[40];
+template<typename T, FFTFunction<T> fft>
+uint8_t                  Tables<T, fft>::num_buffers = 0;
+
+template<typename T, FFTFunction<T> fft>
+WaveTable Tables<T, fft>::Sine;
+template<typename T, FFTFunction<T> fft>
+WaveTable Tables<T, fft>::Square;
+template<typename T, FFTFunction<T> fft>
+WaveTable Tables<T, fft>::Tri;
+template<typename T, FFTFunction<T> fft>
+WaveTable Tables<T, fft>::Saw;
 
 } // namespace daisysp

--- a/Source/Utility/wavetables.h
+++ b/Source/Utility/wavetables.h
@@ -2,7 +2,7 @@
 #include <math.h>
 #include <array>
 #include <vector>
-
+#include <functional>
 #include "dsp.h"
 
 namespace daisysp
@@ -78,7 +78,11 @@ struct WaveTable
     std::vector<WaveBuffer *> buffers;
 };
 
-struct Tables
+template<typename RealType>
+using FFTFunction = void (*)(int, RealType*, RealType*);
+
+template<typename T, FFTFunction<T> fft_func>
+class Tables
 {
     static WaveTable Square;
     static WaveTable Sine;
@@ -298,6 +302,10 @@ struct Tables
         return 0;
     }
 
+    static void fft(int numSamples, T *ar, T *ai) {
+        fft_func(numSamples, ar, ai);
+    }
+
     /*
     in-place complex fft
     
@@ -308,7 +316,7 @@ struct Tables
     Computer Science Dept. 
     Princeton University 08544          
     */
-    static void fft(int numSamples, float *ar, float *ai)
+    static void cooley_tukey_fft(int numSamples, float *ar, float *ai)
     {
         int   i, j, k, L;           /* indexes */
         int   M, TEMP, LE, LE1, ip; /* M = log N */


### PR DESCRIPTION
This pull request converts the struct to a template class, allowing to provide the FFT implementation as a template parameter.

It keeps the previous hard coded function, although with a different name, in the code base. It can be used as a fallback maybe?